### PR TITLE
Fix autosize textarea hook

### DIFF
--- a/hooks/use-autosize-textarea.js
+++ b/hooks/use-autosize-textarea.js
@@ -4,7 +4,7 @@ export function useAutosizeTextArea({
   ref,
   maxHeight = Number.MAX_SAFE_INTEGER,
   borderWidth = 0,
-  dependencies
+  dependencies = []
 }) {
   const originalHeight = useRef(null)
 


### PR DESCRIPTION
## Summary
- avoid undefined spread in `useAutosizeTextArea`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fccb52008329a0777e42589aadc6