### PR TITLE
Improve login and chatbot modes

### DIFF
--- a/app/login/page.js
+++ b/app/login/page.js
@@ -8,7 +8,7 @@ export default function LoginPage() {
   async function handleLogin(formData) {
     "use server";
     try {
-      await signIn("credentials", formData);
+      await signIn("credentials", formData, { redirectTo: "/dashboard" });
     } catch (error) {
       // O erro de redirect é esperado e deve ser tratado pelo Next.js.
       // Verificamos se o erro é o específico de 'NEXT_REDIRECT'. Se for, o relançamos

--- a/components/Brailinho.js
+++ b/components/Brailinho.js
@@ -1,6 +1,7 @@
 "use client"
  
 import { useState } from "react"
+import { useSession } from "next-auth/react"
 import { useChat } from "@ai-sdk/react"
  
 import { cn } from "@/lib/utils"
@@ -21,6 +22,7 @@ const MODELS = [
  
 export function ChatDemo(props) {
   const [selectedModel, setSelectedModel] = useState(MODELS[0].id)
+  const { data: session } = useSession()
   const {
     messages,
     input,
@@ -39,6 +41,20 @@ export function ChatDemo(props) {
   })
  
   const isLoading = status === "submitted" || status === "streaming"
+
+  let suggestions = [
+    "O que é a BrailleWay?",
+    "Quais planos a BrailleWay oferece?",
+  ]
+
+  if (!session) {
+    suggestions.unshift("Como faço login ou cadastro?")
+  } else if (session.user.role === "paciente") {
+    suggestions.unshift("Agendar uma consulta")
+    suggestions.unshift("Quero ver meus dados")
+  } else if (session.user.role === "medico") {
+    suggestions.unshift("Acessar meus dados de médico")
+  }
  
   return (
     <div className={cn("flex", "flex-col", "h-[500px]", "w-full")}>
@@ -68,11 +84,7 @@ export function ChatDemo(props) {
         append={append}
         setMessages={setMessages}
         transcribeAudio={transcribeAudio}
-        suggestions={[
-          "Marcar uma consulta utilizando o Brailinho",
-          "O que é a BrailleWay?",
-          "Quais planos a BrailleWay oferece?",
-        ]}
+        suggestions={suggestions}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- support patient and doctor login flows
- keep user role in the NextAuth session
- redirect to dashboard after login
- personalize Brailinho chatbot by session role
- instruct backend chat endpoint to adapt responses to user role

## Testing
- `npm run build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856feda9d2083299afea869ef70e5ca